### PR TITLE
debian/control: Make `libatspi2.0-dev` depend on `libei-dev`

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -88,6 +88,7 @@ Depends: ${gir:Depends},
          libglib2.0-dev,
          libdbus-1-dev,
          libxtst-dev,
+         libei-dev [amd64 arm64],
 Replaces: gir-repository-dev
 Provides: ${gir:Provides}
 Description: Development files for the assistive technology service provider


### PR DESCRIPTION
Fixes an issue where `pkg-config --cflags gtk+-3.0` errored complaining about libei-1.0 being required by atspi-2.

This should fix Pop!_OS 24.04 CI builds of software depending on GTK.